### PR TITLE
Bug Fixing the SNR - Exptime mismatch

### DIFF
--- a/iris_snr_sim.py
+++ b/iris_snr_sim.py
@@ -1160,7 +1160,7 @@ def IRIS_ETC(filter = "K", mag = 21.0, flambda=1.62e-19, fint=4e-17, itime = 1.0
             if verb > 1: print "Mean time (mean aperture flux) = %.4f seconds" % np.mean(totime_cutout_aperlselect)
             if verb > 1: print 'Time (aperture = %.4f") = %.4f' % (sizel, totimel)
 
-            totalexptimel= str("%0.4f" %totimel) # integrated aperture exptime at pre-defined fixed aperture 
+            #totalexptimel= str("%0.4f" %totimel) # integrated aperture exptime at pre-defined fixed aperture 
             ####################
             # Main exposure plot
             ####################
@@ -1386,8 +1386,28 @@ def IRIS_ETC(filter = "K", mag = 21.0, flambda=1.62e-19, fint=4e-17, itime = 1.0
             ###########################
             # summation of the aperture
             ###########################
-            snr_int = phot_table["aperture_sum"].quantity/phot_table["aperture_sum_err"].quantity
-            if verb > 1: print 'S/N (aperture = %.4f") = %.4f' % (sizel, snr_int[0])
+            
+
+
+            if photutils.__version__ == "0.4":
+                data_cutout_aper = mask.multiply(tmtImage) # in version 0.4 of photutils
+                data_cutout_aperl = maskl.multiply(tmtImage) # in version 0.4 of photutils
+                noise_cutout_aperl = maskl.multiply(flatarray)*noisetotal
+            else:
+                data_cutout_aper = mask.apply(tmtImage)
+                data_cutout_aperl = maskl.apply(tmtImage)
+                noise_cutout_aperl = maskl.apply(flatarray)*noisetotal
+
+            aper_totsuml = data_cutout_aperl.sum()+noise_cutout_aperl.sum()
+            aper_suml = data_cutout_aperl.sum()
+
+
+      
+            #Change to more classical sum for SNR rather than using phot_table
+	    snr_int=(aper_suml*np.sqrt(nframes*itime))/(np.sqrt(aper_totsuml))
+            #snr_int = phot_table["aperture_sum"].quantity/phot_table["aperture_sum_err"].quantity
+            
+            if verb > 1: print 'S/N (aperture = %.4f") = %.4f' % (sizel, snr_int)
             
             if verb > 1:
                 phot_table = aperture_photometry(signal, apertures, error=noisemap)
@@ -1528,11 +1548,11 @@ def IRIS_ETC(filter = "K", mag = 21.0, flambda=1.62e-19, fint=4e-17, itime = 1.0
             if photutils.__version__ == "0.4":
                 data_cutout_aper = mask.multiply(tmtImage) # in version 0.4 of photutils
                 data_cutout_aperl = maskl.multiply(tmtImage) # in version 0.4 of photutils
-                noise_cutout_aperl = maskl.multiply(flatarray)+noisetotal
+                noise_cutout_aperl = maskl.multiply(flatarray)*noisetotal
             else:
                 data_cutout_aper = mask.apply(tmtImage)
                 data_cutout_aperl = maskl.apply(tmtImage)
-                noise_cutout_aperl = maskl.apply(flatarray)+noisetotal
+                noise_cutout_aperl = maskl.apply(flatarray)*noisetotal
             
             
             aper_totsuml = data_cutout_aperl.sum()+noise_cutout_aperl.sum()
@@ -1554,10 +1574,7 @@ def IRIS_ETC(filter = "K", mag = 21.0, flambda=1.62e-19, fint=4e-17, itime = 1.0
     else:
         inputstr= 'Input integration time [s]'
         inputvalue=str(nframes*itime)
-    if source == "extended":
-        magadd='[per square arcsecond]'
-    else:
-        magadd=''
+
     if mode == 'imager':
         saturatedstr=str(saturated)
         resolutionstr=''  
@@ -1566,6 +1583,16 @@ def IRIS_ETC(filter = "K", mag = 21.0, flambda=1.62e-19, fint=4e-17, itime = 1.0
         saturatedstr=''
         resolutionstr=str(resolution)
         aperture_str="{:.3f}".format(sizel)+'"'
+
+    if source == "extended":
+        magadd='[per square arcsecond]'
+        if saturated > 0 :
+            saturatedstr='True'
+        else:
+            saturatedstr='False'
+    else:
+        magadd=''        
+        
         
     if fint is not None:
 	fintstr= str("%0.4e" %fint)

--- a/iris_snr_sim.py
+++ b/iris_snr_sim.py
@@ -1404,7 +1404,7 @@ def IRIS_ETC(filter = "K", mag = 21.0, flambda=1.62e-19, fint=4e-17, itime = 1.0
 
       
             #Change to more classical sum for SNR rather than using phot_table
-	    snr_int=(aper_suml*np.sqrt(nframes*itime))/(np.sqrt(aper_totsuml))
+            snr_int=(aper_suml*np.sqrt(nframes*itime))/(np.sqrt(aper_totsuml))
             #snr_int = phot_table["aperture_sum"].quantity/phot_table["aperture_sum_err"].quantity
             
             if verb > 1: print 'S/N (aperture = %.4f") = %.4f' % (sizel, snr_int)
@@ -1595,14 +1595,14 @@ def IRIS_ETC(filter = "K", mag = 21.0, flambda=1.62e-19, fint=4e-17, itime = 1.0
         
         
     if fint is not None:
-	fintstr= str("%0.4e" %fint)
-	magstr=''
-	flambdastr=''
+        fintstr= str("%0.4e" %fint)
+        magstr=''
+        flambdastr=''
     else:
-	fintstr=''
-	magstr= str(mag)
-	flambdastr=str("%0.4e" %flambda)
-	
+        fintstr=''
+        magstr= str(mag)
+        flambdastr=str("%0.4e" %flambda)
+        
 
     jsondict=OrderedDict([(inputstr,inputvalue),('Filter',str(filter)), ('Central Wavelength [microns]',"{:.3f}".format(lambdac[0]*.0001)),('Resolution',resolutionstr),('Magnitude of Source [Vega]'+magadd,magstr),("Flux density of Source [erg/s/cm^2/Ang]",flambdastr),("Integrated Flux over bandpass [erg/s/cm^2]",fintstr),("Aperture Size",aperture_str),('Peak Value of SNR',peakSNR),('SNR for Total Flux (Aperture = '+"{:.3f}".format(sizel)+'")',totalSNRl),('Median Value of SNR (Aperture = '+"{:.3f}".format(sizel)+'")',medianSNRl),('Mean Value of SNR (Aperture = '+"{:.3f}".format(sizel)+'")',meanSNRl),('Median Value of SNR (Aperture =0.4")',medianSNR),('Mean Value of SNR (Aperture =0.4")',meanSNR),('Total integration time [s] for Peak Flux ',minexptime),('Total integration time [s] for Median Flux (Aperture = '+"{:.3f}".format(sizel)+'")',medianexptimel),('Total integration time [s] for Mean Flux (Aperture = '+"{:.3f}".format(sizel)+'")',meanexptimel),('Total integration time [s] for Total Flux (Aperture = '+"{:.3f}".format(sizel)+'")',totalexptimel),('Saturated Pixels',saturatedstr)])
     print(json.dumps(jsondict))


### PR DESCRIPTION
Changes 
- The SNR calculation for the aperture in the imager changed to the classical mode and not using phot utils.
- The saturation  flags are changed  for extended object